### PR TITLE
Require compression via attribute

### DIFF
--- a/CompressR.sln
+++ b/CompressR.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompressR.WebApi", "src\Com
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompressR.Sample", "src\CompressR.Sample\CompressR.Sample.csproj", "{2FA56DF3-C7B2-4070-B41A-FE328D96961C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompressR", "src\CompressR\CompressR.csproj", "{C94378C3-4AA8-4F49-8720-77D14B62F72E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\CompressR.MVC\CompressR.MVC.projitems*{b8889368-e350-4b1e-82f5-ea537d6da6e9}*SharedItemsImports = 4
@@ -40,6 +42,10 @@ Global
 		{2FA56DF3-C7B2-4070-B41A-FE328D96961C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FA56DF3-C7B2-4070-B41A-FE328D96961C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FA56DF3-C7B2-4070-B41A-FE328D96961C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C94378C3-4AA8-4F49-8720-77D14B62F72E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C94378C3-4AA8-4F49-8720-77D14B62F72E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C94378C3-4AA8-4F49-8720-77D14B62F72E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C94378C3-4AA8-4F49-8720-77D14B62F72E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CompressR.MVC4/CompressR.MVC4.csproj
+++ b/src/CompressR.MVC4/CompressR.MVC4.csproj
@@ -75,6 +75,12 @@
     <None Include="CompressR.MVC4.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CompressR\CompressR.csproj">
+      <Project>{c94378c3-4aa8-4f49-8720-77d14b62f72e}</Project>
+      <Name>CompressR</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\CompressR.MVC\CompressR.MVC.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/CompressR.MVC5/CompressR.MVC5.csproj
+++ b/src/CompressR.MVC5/CompressR.MVC5.csproj
@@ -75,6 +75,12 @@
     <None Include="CompressR.MVC5.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CompressR\CompressR.csproj">
+      <Project>{c94378c3-4aa8-4f49-8720-77d14b62f72e}</Project>
+      <Name>CompressR</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\CompressR.MVC\CompressR.MVC.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/CompressR.WebApi/CompressAttribute.cs
+++ b/src/CompressR.WebApi/CompressAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CompressR.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
@@ -35,7 +36,7 @@ namespace CompressR.WebApi
             if (string.IsNullOrWhiteSpace(acceptedEncoding))
             {
                 if (RequireCompression)
-                    throw new Exception("Compression required but client did not send accept header");
+                    throw new CompressRException("Compression required but client did not send accept header");
                 else
                     return;
             }

--- a/src/CompressR.WebApi/CompressAttribute.cs
+++ b/src/CompressR.WebApi/CompressAttribute.cs
@@ -14,6 +14,13 @@ namespace CompressR.WebApi
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public sealed class CompressAttribute : System.Web.Http.Filters.ActionFilterAttribute
     {
+        private bool RequireCompression { get; set; }
+
+        public CompressAttribute(bool requireCompression = false)
+        {
+            RequireCompression = requireCompression;
+        }
+
         public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
         {
             var acceptedEncoding = actionExecutedContext
@@ -27,7 +34,10 @@ namespace CompressR.WebApi
 
             if (string.IsNullOrWhiteSpace(acceptedEncoding))
             {
-                return;
+                if (RequireCompression)
+                    throw new Exception("Compression required but client did not send accept header");
+                else
+                    return;
             }
 
             actionExecutedContext.Response.Content = new CompressedContent(actionExecutedContext.Response.Content, acceptedEncoding);

--- a/src/CompressR/CompressR.csproj
+++ b/src/CompressR/CompressR.csproj
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A7545CCD-C684-4A5D-ABFD-ACFD839B9128}</ProjectGuid>
+    <ProjectGuid>{C94378C3-4AA8-4F49-8720-77D14B62F72E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CompressR.WebApi</RootNamespace>
-    <AssemblyName>CompressR.WebApi</AssemblyName>
+    <RootNamespace>CompressR</RootNamespace>
+    <AssemblyName>CompressR</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,20 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -53,22 +40,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CompressedContent.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="DeflateAttribute.cs" />
-    <Compile Include="CompressAttribute.cs" />
-    <Compile Include="GzipAttribute.cs" />
+    <Compile Include="Exceptions\CompressRException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="CompressR.WebApi.nuspec" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CompressR\CompressR.csproj">
-      <Project>{c94378c3-4aa8-4f49-8720-77d14b62f72e}</Project>
-      <Name>CompressR</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/CompressR/Exceptions/CompressRException.cs
+++ b/src/CompressR/Exceptions/CompressRException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CompressR.Exceptions
+{
+    public class CompressRException: Exception
+    {
+        public CompressRException(string message) : base(message) { }
+    }
+}

--- a/src/CompressR/Properties/AssemblyInfo.cs
+++ b/src/CompressR/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CompressR")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("CompressR")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c94378c3-4aa8-4f49-8720-77d14b62f72e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
As we discussed earlier, required compression for use in internal API endpoints
